### PR TITLE
Fa 6 4 quiet logs

### DIFF
--- a/mapimageio.c
+++ b/mapimageio.c
@@ -1307,6 +1307,13 @@ int readGIF(char *path, rasterBufferObj *rb)
 
   } while (recordType != TERMINATE_RECORD_TYPE);
 
+
+#if defined GIFLIB_MAJOR && GIFLIB_MINOR && ((GIFLIB_MAJOR == 5 && GIFLIB_MINOR >= 1) || (GIFLIB_MAJOR > 5))
+  if (DGifCloseFile(image, &errcode) == GIF_ERROR) {
+    msSetError(MS_MISCERR,"failed to close gif after loading: %s","readGIF()", gif_error_msg(errcode));
+    return MS_FAILURE;
+  }
+#else
   if (DGifCloseFile(image) == GIF_ERROR) {
 #if defined GIFLIB_MAJOR && GIFLIB_MAJOR >= 5
     msSetError(MS_MISCERR,"failed to close gif after loading: %s","readGIF()", gif_error_msg(image->Error));
@@ -1315,6 +1322,7 @@ int readGIF(char *path, rasterBufferObj *rb)
 #endif
     return MS_FAILURE;
   }
+#endif
 
   return MS_SUCCESS;
 }

--- a/mapproject.c
+++ b/mapproject.c
@@ -115,7 +115,11 @@ int msProjectPoint(projectionObj *in, projectionObj *out, pointObj *point)
 #endif
 
     if( error || point->x == HUGE_VAL || point->y == HUGE_VAL ) {
+	/* This is generating too much noise in our (FlightAware) logs, so commenting it out
+		Note: the MAPSCRIPT layer was reporting the same error to the log, via
+        trickle down from this call, so this also disables the MAPSCRIPT reported version 
       msSetError(MS_PROJERR,"proj says: %s","msProjectPoint()",pj_strerrno(error));
+	 */
       return MS_FAILURE;
     }
 


### PR DESCRIPTION
Eliminate Projection library errors from out of bounds points filling up the logs.